### PR TITLE
Continue reading until EOF (88% fix)

### DIFF
--- a/zspotify/podcast.py
+++ b/zspotify/podcast.py
@@ -118,10 +118,12 @@ def download_episode(episode_id) -> None:
                 unit_divisor=1024
             ) as p_bar:
                 prepare_download_loader.stop()
-                for _ in range(int(total_size / ZSpotify.CONFIG.get_chunk_size()) + 1):
+                while total_size > downloaded:
                     data = stream.input_stream.stream().read(ZSpotify.CONFIG.get_chunk_size())
                     p_bar.update(file.write(data))
                     downloaded += len(data)
+                    if len(data) == 0:
+                        break
                     if ZSpotify.CONFIG.get_download_real_time():
                         delta_real = time.time() - time_start
                         delta_want = (downloaded / total_size) * (duration_ms/1000)

--- a/zspotify/track.py
+++ b/zspotify/track.py
@@ -199,10 +199,12 @@ def download_track(mode: str, track_id: str, extra_keys=None, disable_progressba
                             unit_divisor=1024,
                             disable=disable_progressbar
                     ) as p_bar:
-                        for _ in range(int(total_size / ZSpotify.CONFIG.get_chunk_size()) + 1):
+                        while total_size > downloaded:
                             data = stream.input_stream.stream().read(ZSpotify.CONFIG.get_chunk_size())
                             p_bar.update(file.write(data))
                             downloaded += len(data)
+                            if len(data) == 0:
+                                break
                             if ZSpotify.CONFIG.get_download_real_time():
                                 delta_real = time.time() - time_start
                                 delta_want = (downloaded / total_size) * (duration_ms/1000)


### PR DESCRIPTION
Previously this read a fixed number of chunks irrespectiv of the amount of data in the chunks, the effect of this was that read stoped around 88% unless the chunks size was set inefficiently low

My current ISP here atm sadly prevents me from listening to spotify the normal way live in reality, the fix people suggest on the web with chunk size changes is wrong so i had to fix this ...

Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>