### PR TITLE
Fix podcasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ The value is relative to the `ROOT_PATH`/`ROOT_PODCAST_PATH` directory and can c
 | {album_num}     | (only when downloading albums) Incrementing track number
 | {playlist}      | (only when downloading playlists) Name of the playlist 
 | {playlist_num}  | (only when downloading playlists) Incrementing track number
+| {podcast}  | (only when downloading podcasts) Name of the podcast 
+| {episode_name}  | (only when downloading podcasts) Name of the episode
+| {release_date}  | (only when downloading podcasts) Release date of the episode
 
 Example values could be:
 ~~~~

--- a/zspotify/config.py
+++ b/zspotify/config.py
@@ -69,6 +69,7 @@ OUTPUT_DEFAULT_PLAYLIST_EXT = '{playlist}/{playlist_num} - {artist} - {song_name
 OUTPUT_DEFAULT_LIKED_SONGS = 'Liked Songs/{artist} - {song_name}.{ext}'
 OUTPUT_DEFAULT_SINGLE = '{artist} - {song_name}.{ext}'
 OUTPUT_DEFAULT_ALBUM = '{artist}/{album}/{album_num} - {artist} - {song_name}.{ext}'
+OUTPUT_DEFAULT_PODCAST = '{podcast}/{episode_name}.{ext}'
 
 
 class Config:
@@ -244,6 +245,11 @@ class Config:
                 split = os.path.split(OUTPUT_DEFAULT_ALBUM)
                 return os.path.join(split[0], 'Disc {disc_number}', split[0])
             return OUTPUT_DEFAULT_ALBUM
+        if mode == 'podcast':
+            if cls.get_split_album_discs():
+                split = os.path.split(OUTPUT_DEFAULT_PODCAST)
+                return os.path.join(split[0], 'Disc {disc_number}', split[0])
+            return OUTPUT_DEFAULT_PODCAST
         raise ValueError()
 
     @classmethod

--- a/zspotify/podcast.py
+++ b/zspotify/podcast.py
@@ -83,54 +83,48 @@ def download_episode(episode_id) -> None:
     else:
         filename = podcast_name + ' - ' + episode_name
 
-        direct_download_url = ZSpotify.invoke_url(
-            'https://api-partner.spotify.com/pathfinder/v1/query?operationName=getEpisode&variables={"uri":"spotify:episode:' + episode_id + '"}&extensions={"persistedQuery":{"version":1,"sha256Hash":"224ba0fd89fcfdfb3a15fa2d82a6112d3f4e2ac88fba5c6713de04d1b72cf482"}}')[1]["data"]["episode"]["audio"]["items"][-1]["url"]
-
         download_directory = os.path.join(ZSpotify.CONFIG.get_root_podcast_path(), extra_paths)
         download_directory = os.path.realpath(download_directory)
         create_download_directory(download_directory)
 
-        if "anon-podcast.scdn.co" in direct_download_url:
-            episode_id = EpisodeId.from_base62(episode_id)
-            stream = ZSpotify.get_content_stream(
-                episode_id, ZSpotify.DOWNLOAD_QUALITY)
+        
+        episode_id = EpisodeId.from_base62(episode_id)
+        stream = ZSpotify.get_content_stream(
+            episode_id, ZSpotify.DOWNLOAD_QUALITY)
 
-            total_size = stream.input_stream.size
+        total_size = stream.input_stream.size
 
-            filepath = os.path.join(download_directory, f"{filename}.ogg")
-            if (
-                os.path.isfile(filepath)
-                and os.path.getsize(filepath) == total_size
-                and ZSpotify.CONFIG.get_skip_existing_files()
-            ):
-                Printer.print(PrintChannel.SKIPS, "\n###   SKIPPING: " + podcast_name + " - " + episode_name + " (EPISODE ALREADY EXISTS)   ###")
-                prepare_download_loader.stop()
-                return
-
+        filepath = os.path.join(download_directory, f"{filename}.ogg")
+        if (
+            os.path.isfile(filepath)
+            and os.path.getsize(filepath) == total_size
+            and ZSpotify.CONFIG.get_skip_existing_files()
+        ):
+            Printer.print(PrintChannel.SKIPS, "\n###   SKIPPING: " + podcast_name + " - " + episode_name + " (EPISODE ALREADY EXISTS)   ###")
             prepare_download_loader.stop()
-            time_start = time.time()
-            downloaded = 0
-            with open(filepath, 'wb') as file, Printer.progress(
-                desc=filename,
-                total=total_size,
-                unit='B',
-                unit_scale=True,
-                unit_divisor=1024
-            ) as p_bar:
-                prepare_download_loader.stop()
-                while total_size > downloaded:
-                    data = stream.input_stream.stream().read(ZSpotify.CONFIG.get_chunk_size())
-                    p_bar.update(file.write(data))
-                    downloaded += len(data)
-                    if len(data) == 0:
-                        break
-                    if ZSpotify.CONFIG.get_download_real_time():
-                        delta_real = time.time() - time_start
-                        delta_want = (downloaded / total_size) * (duration_ms/1000)
-                        if delta_want > delta_real:
-                            time.sleep(delta_want - delta_real)
-        else:
-            filepath = os.path.join(download_directory, f"{filename}.mp3")
-            download_podcast_directly(direct_download_url, filepath)
+            return
+
+        prepare_download_loader.stop()
+        time_start = time.time()
+        downloaded = 0
+        with open(filepath, 'wb') as file, Printer.progress(
+            desc=filename,
+            total=total_size,
+            unit='B',
+            unit_scale=True,
+            unit_divisor=1024
+        ) as p_bar:
+            prepare_download_loader.stop()
+            while total_size > downloaded:
+                data = stream.input_stream.stream().read(ZSpotify.CONFIG.get_chunk_size())
+                p_bar.update(file.write(data))
+                downloaded += len(data)
+                if len(data) == 0:
+                    break
+                if ZSpotify.CONFIG.get_download_real_time():
+                    delta_real = time.time() - time_start
+                    delta_want = (downloaded / total_size) * (duration_ms/1000)
+                    if delta_want > delta_real:
+                        time.sleep(delta_want - delta_real)
 
     prepare_download_loader.stop()


### PR DESCRIPTION
Spotify's API had some changes a few months ago, and so the current code in clspotify doesn't handle podcasts correctly. This was fixed by kokarare1212/librespot-python#135 in librespot, but clspotify still needs to be updated to use the correct methods.

I am not a python programmer, so please excuse my bad code here. I tried following how tracks are downloaded.

My PR:
- allows podcasts to be downloaded once again
- adds output file path template options for podcasts (Such as `--output "{podcast}/{episode_name}.{ext}"`)
- converts file (In case `--download-format` is set to something else)

As I said, I don't ever write code in python, but the repo doesn't have issues open and I wanted this fixed and so I decided I'd try my best to fix it myself with a PR. for cleanliness, I'm sure someone better would be interested in making changes, but my version at the very least brings back support for podcasts.