### PR TITLE
Add option to skip any song that exists on disk, no matter the origin

### DIFF
--- a/zspotify/config.py
+++ b/zspotify/config.py
@@ -8,6 +8,7 @@ ROOT_PATH = 'ROOT_PATH'
 ROOT_PODCAST_PATH = 'ROOT_PODCAST_PATH'
 SKIP_EXISTING_FILES = 'SKIP_EXISTING_FILES'
 SKIP_PREVIOUSLY_DOWNLOADED = 'SKIP_PREVIOUSLY_DOWNLOADED'
+SKIP_EXISTING_ANY_ORIGIN = 'SKIP_EXISTING_ANY_ORIGIN'
 DOWNLOAD_FORMAT = 'DOWNLOAD_FORMAT'
 FORCE_PREMIUM = 'FORCE_PREMIUM'
 ANTI_BAN_WAIT_TIME = 'ANTI_BAN_WAIT_TIME'
@@ -38,6 +39,7 @@ CONFIG_VALUES = {
     ROOT_PODCAST_PATH:          { 'default': '../ZSpotify Podcasts/', 'type': str,  'arg': '--root-podcast-path'          },
     SKIP_EXISTING_FILES:        { 'default': 'True',                  'type': bool, 'arg': '--skip-existing-files'        },
     SKIP_PREVIOUSLY_DOWNLOADED: { 'default': 'False',                 'type': bool, 'arg': '--skip-previously-downloaded' },
+    SKIP_EXISTING_ANY_ORIGIN:   {'default': 'True',                   'type': bool, 'arg': '--skip-existing-any-origin'},
     RETRY_ATTEMPTS:             { 'default': '5',                     'type': int,  'arg': '--retry-attemps'              },
     DOWNLOAD_FORMAT:            { 'default': 'ogg',                   'type': str,  'arg': '--download-format'            },
     FORCE_PREMIUM:              { 'default': 'False',                 'type': bool, 'arg': '--force-premium'              },
@@ -156,6 +158,10 @@ class Config:
     @classmethod
     def get_skip_previously_downloaded(cls) -> bool:
         return cls.get(SKIP_PREVIOUSLY_DOWNLOADED)
+
+    @classmethod
+    def get_skip_existing_any_origin(cls) -> bool:
+        return cls.get(SKIP_EXISTING_ANY_ORIGIN)
 
     @classmethod
     def get_split_album_discs(cls) -> bool:

--- a/zspotify/track.py
+++ b/zspotify/track.py
@@ -147,8 +147,8 @@ def download_track(mode: str, track_id: str, extra_keys=None, disable_progressba
         check_id = scraped_song_id in get_directory_song_ids(filedir)
         check_all_time = scraped_song_id in get_previously_downloaded()
 
-        # a song with the same name is installed
-        if not check_id and check_name:
+        # a file with the same name exists in the directory, but song not in the downloaded songs list
+        if not check_id and check_name and not ZSpotify.CONFIG.get_skip_existing_any_origin():
             c = len([file for file in os.listdir(filedir) if re.search(f'^{filename}_', str(file))]) + 1
 
             fname = os.path.splitext(os.path.basename(filename))[0]
@@ -174,6 +174,10 @@ def download_track(mode: str, track_id: str, extra_keys=None, disable_progressba
                 if check_id and check_name and ZSpotify.CONFIG.get_skip_existing_files():
                     prepare_download_loader.stop()
                     Printer.print(PrintChannel.SKIPS, '\n###   SKIPPING: ' + song_name + ' (SONG ALREADY EXISTS)   ###' + "\n")
+
+                elif check_name and ZSpotify.CONFIG.get_skip_existing_any_origin():
+                    prepare_download_loader.stop()
+                    Printer.print(PrintChannel.SKIPS, '\n###   SKIPPING: ' + song_name + ' (SONG ALREADY EXISTS BUT WAS NOT DOWNLOADED WITH CLSPOTIFY)   ###' + "\n")
 
                 elif check_all_time and ZSpotify.CONFIG.get_skip_previously_downloaded():
                     prepare_download_loader.stop()


### PR DESCRIPTION
I find the option `--skip-existing-files` doesn't work for me, it only skips songs if they are written to the `.song_ids`-file AND exist on disk. I want to run it on existing music libraries so I added `--skip-existing-any-origin` to compare ONLY against whether the file exists on disk, no matter if it was downloaded from clspotify or just exists there.
Previously it just writes a new file and adds a suffix (`filename_1.ogg`).

Doesn't change default behavior and doesn't change what existing option flags do.

Only caveat: if a file is corrupted or incomplete during download, it will now look like the file exists. The file is not checked on sum, size or song-duration. From my point of view, this is intended.